### PR TITLE
fixing issues with ERA5 climate

### DIFF
--- a/hrldas/HRLDAS_forcing/create_forcing.F
+++ b/hrldas/HRLDAS_forcing/create_forcing.F
@@ -1259,7 +1259,11 @@ contains
           call latlon_to_ij(datastruct%proj, geo_em%lat(i,j), east_longitude, etax(i,j), etay(i,j))
 #else
           if (forcing_type=="ERA5") then
-            call latlon_to_ij(datastruct%proj, geo_em%lat(i,j), geo_em%lon(i,j)+360., etax(i,j), etay(i,j))
+            if (geo_em%lon(i,j) < 0) then
+              call latlon_to_ij(datastruct%proj, geo_em%lat(i,j), geo_em%lon(i,j)+360., etax(i,j), etay(i,j))
+            else
+              call latlon_to_ij(datastruct%proj, geo_em%lat(i,j), geo_em%lon(i,j), etax(i,j), etay(i,j))
+            endif
           else
             call latlon_to_ij(datastruct%proj, geo_em%lat(i,j), geo_em%lon(i,j), etax(i,j), etay(i,j))
           endif

--- a/hrldas/HRLDAS_forcing/run/examples/ERA5/namelist.input.ERA5
+++ b/hrldas/HRLDAS_forcing/run/examples/ERA5/namelist.input.ERA5
@@ -52,7 +52,7 @@ GRIB1| Level| From |  To  |          |          |                               
 Param| Type |Level1|Level2| Name     | Units    | Description                              |Discp|Catgy|Param|Level|
 -----+------+------+------+----------+----------+------------------------------------------+-----------------------+
  134 |  1   |   0  |      | PSFC     | Pa       |                                          |  0  |  3  |  0  |  1  |
- 129 |  1   |   0  |      | z        | m2 s-2   | Geopotential                             |  0  |  3  |  4  |  1  |
+ 129 |  1   |   0  |      | TERRAIN  | m2 s-2   | Geopotential                             |  0  |  3  |  4  |  1  |
  172 |  1   |   0  |      | LANDSEA  | fraction | Land/Sea flag                            |  2  |  0  |  0  |  1  |
  157 | 109  |   0  |      | RH       | %        | Relative Humidity                        |  0  |  1  |  1  | 105 |
  165 |  1   |   0  |      | U2D      | m s-1    | U                                        |  0  |  2  |  2  | 103 |


### PR DESCRIPTION
#56 
Namelist Vtable, z changed to TERRAIN
call latlon_to_ij() don’t need to +360.0 for ERA5 data, if longitude is positive. 
