### PR TITLE
Implementing refactor wetland code from Zhang et al. (2022) WRR 

### DIFF
--- a/hrldas/IO_code/module_NoahMP_hrldas_driver.F
+++ b/hrldas/IO_code/module_NoahMP_hrldas_driver.F
@@ -59,7 +59,7 @@ contains
     implicit none
 
     integer      :: NTIME_out
-    real         :: max_landtype2d
+    real         :: max_utype_urb2d
     type(domain) :: grid
     ! initilization for stand alone parallel code.
     integer, optional, intent(in) :: wrfits,wrfite,wrfjts,wrfjte
@@ -180,9 +180,9 @@ contains
     NoahmpIO%kme = 2
   
     if ( (NoahmpIO%sf_urban_physics == 2) .or. (NoahmpIO%sf_urban_physics == 3) ) then
-       NoahmpIO%kde = NoahmpIO%num_urban_atmosphere + 1  ! to be consistent with kme
-       NoahmpIO%kme = NoahmpIO%num_urban_atmosphere + 1  ! bug fix for dimension of urban cell interfaces
+       NoahmpIO%kde = NoahmpIO%num_urban_atmosphere
        NoahmpIO%kte = NoahmpIO%num_urban_atmosphere
+       NoahmpIO%kme = NoahmpIO%num_urban_atmosphere
     endif
 
 !---------------------------------------------------------------------
@@ -281,6 +281,16 @@ contains
     if (NoahmpIO%IOPT_CROP == 1) then ! use crop_option=1 for reading crop extra fields
        call READ_CROP_INPUT(NoahmpIO%HRLDAS_SETUP_FILE, NoahmpIO%XSTART, NoahmpIO%XEND, NoahmpIO%YSTART, NoahmpIO%YEND,&
                             NoahmpIO%CROPTYPE, NoahmpIO%PLANTING, NoahmpIO%HARVEST, NoahmpIO%SEASON_GDD)
+    endif
+
+!------------------------------------------------------------------------
+! For surface wetland scheme, read in necessary extra fields 
+!------------------------------------------------------------------------
+    NoahmpIO%FSATMX     = 0.38
+    NoahmpIO%WCAP       = 0.1 
+    if (NoahmpIO%IOPT_WETLAND == 2) then ! use wetland_option=2 for reading wetland extra fields
+       call READ_WETLAND_INPUT(NoahmpIO%HRLDAS_SETUP_FILE, NoahmpIO%XSTART, NoahmpIO%XEND, NoahmpIO%YSTART, NoahmpIO%YEND,&
+                               NoahmpIO%FSATMX,NoahmpIO%WCAP)
     endif
 
 !------------------------------------------------------------------------
@@ -555,11 +565,12 @@ contains
                               NoahmpIO%DL_U_BEP, NoahmpIO%SF_BEP, NoahmpIO%VL_BEP,                                          & !multi-layer urban
                               NoahmpIO%FRC_URB2D, NoahmpIO%UTYPE_URB2D, NoahmpIO%use_wudapt_lcz)                              !urban
 
-          max_landtype2d = maxval(NoahmpIO%IVGTYP)*1.0
-          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_landtype2d > 50.0) ) then   ! LCZ number: 51~61
+          max_utype_urb2d = maxval(NoahmpIO%UTYPE_URB2D)*1.0
+
+          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_utype_urb2d > 3.0) ) then  !new LCZ
              stop "USING 10 WUDAPT LCZ WITHOUT URBPARM_LCZ.TBL. SET USE_WUDAPT_LCZ=1"
           endif
-          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_landtype2d <= 50.0) ) then  ! LCZ number: 51~61
+          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_utype_urb2d <= 3.0) ) then  ! new LCZ
              stop "USING URBPARM_LCZ.TBL WITH OLD 3 URBAN CLASSES. SET USE_WUDAPT_LCZ=0"
           endif
 
@@ -693,14 +704,14 @@ contains
                               NoahmpIO%DL_U_BEP, NoahmpIO%SF_BEP, NoahmpIO%VL_BEP,                                         & !multi-layer urban
                               NoahmpIO%FRC_URB2D, NoahmpIO%UTYPE_URB2D, NoahmpIO%use_wudapt_lcz)                             !urban
 
-          max_landtype2d = maxval(NoahmpIO%IVGTYP)*1.0
-          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_landtype2d > 50.0) ) then   ! LCZ number: 51~61
+          max_utype_urb2d = maxval(NoahmpIO%UTYPE_URB2D)*1.0
+               
+          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_utype_urb2d > 3.0) ) then  !new LCZ
              stop "USING 10 WUDAPT LCZ WITHOUT URBPARM_LCZ.TBL. SET USE_WUDAPT_LCZ=1"
           endif
-          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_landtype2d <= 50.0) ) then  ! LCZ number: 51~61
+          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_utype_urb2d <= 3.0) ) then  ! new LCZ
              stop "USING URBPARM_LCZ.TBL WITH OLD 3 URBAN CLASSES. SET USE_WUDAPT_LCZ=0"
           endif
-
        endif !urban
 
        if ( NoahmpIO%SF_URBAN_PHYSICS > 1 ) then  !urban
@@ -873,37 +884,27 @@ contains
      NoahmpIO%SWDDIF = NoahmpIO%SWDOWN * 0.3                    ! following noahmplsm ATM 30% diffuse radiation
 
      IF(NoahmpIO%SF_URBAN_PHYSICS == 2 .or. NoahmpIO%SF_URBAN_PHYSICS == 3) THEN  ! BEP or BEM urban models
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban    (:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban  (:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:) /287.04/NoahmpIO%t_phy(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban(:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:) /287.04/NoahmpIO%t_phy(:,1,:)
        where(NoahmpIO%XLAND < 1.5) NoahmpIO%theta_urban(:,NoahmpIO%kde,:) = NoahmpIO%t_phy(:,1,:)*&
-                                                                            (100000.0/NoahmpIO%p8w(:,1,:))**(0.285714)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban    (:,NoahmpIO%kde,:) = NoahmpIO%u_phy(:,1,:)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban    (:,NoahmpIO%kde,:) = NoahmpIO%v_phy(:,1,:)
-
-       ! allow one more dummy layer at the top to be consistent with cell interface array dimension
-       NoahmpIO%p_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%p_urban(:,NoahmpIO%kde,:)
-       NoahmpIO%rho_urban  (:,NoahmpIO%kde-1,:) = NoahmpIO%rho_urban(:,NoahmpIO%kde,:)
-       NoahmpIO%theta_urban(:,NoahmpIO%kde-1,:) = NoahmpIO%theta_urban(:,NoahmpIO%kde,:)
-       NoahmpIO%u_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%u_urban(:,NoahmpIO%kde,:)
-       NoahmpIO%v_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%v_urban(:,NoahmpIO%kde,:)
-
-       NoahmpIO%height_urban = 0.5*(NoahmpIO%dz_urban(1,NoahmpIO%kde-1,1) + &
-                               NoahmpIO%dz_urban(1,NoahmpIO%kde-2,1))
+                                                                   (100000.0/NoahmpIO%p8w(:,1,:))**(0.285714)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban(:,NoahmpIO%kde,:) = NoahmpIO%u_phy(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban(:,NoahmpIO%kde,:) = NoahmpIO%v_phy(:,1,:)
        
-       do i = 3, NoahmpIO%kde
-           where(NoahmpIO%XLAND < 1.5) NoahmpIO%QV_CURR(:,i,:) = NoahmpIO%QV_CURR(:,1,:)
-       enddo
+       NoahmpIO%height_urban = 0.5*(NoahmpIO%dz_urban(1,NoahmpIO%kde,1) + &
+                                 NoahmpIO%dz_urban(1,NoahmpIO%kde-1,1))
 
-       DO I = NoahmpIO%kde-2, NoahmpIO%kds, -1
+       DO I = NoahmpIO%KDE-1, NoahmpIO%KDS, -1
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban(:,i,:) = NoahmpIO%p8w(:,1,:)* &
-                                                               exp(9.8*NoahmpIO%height_urban/287.04/NoahmpIO%t_phy(:,1,:))
-         where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,i,:) = NoahmpIO%p_urban(:,i,:)/287.04/NoahmpIO%t_phy(:,1,:)
+                                                             exp(9.8*NoahmpIO%height_urban/287.04/NoahmpIO%t_phy(:,1,:))
+         where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,i,:) = NoahmpIO%p_urban(:,i,:)/287.04/ &
+                                                             NoahmpIO%t_phy(:,1,:)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%theta_urban(:,i,:) = NoahmpIO%t_phy(:,1,:)* &
-                                                                   (100000.0/NoahmpIO%p_urban(:,i,:))**(0.285714)
+                                                             (100000.0/NoahmpIO%p_urban(:,i,:))**(0.285714)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban(:,i,:) = NoahmpIO%u_urban(:,NoahmpIO%kde,:)* &
-                                                               log(max(NoahmpIO%zlvl-NoahmpIO%height_urban,1.001))/log(NoahmpIO%zlvl)
+                                                             log(NoahmpIO%zlvl-NoahmpIO%height_urban)/log(NoahmpIO%zlvl)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban(:,i,:) = NoahmpIO%v_urban(:,NoahmpIO%kde,:)* &
-                                                               log(max(NoahmpIO%zlvl-NoahmpIO%height_urban,1.001))/log(NoahmpIO%zlvl)
+                                                             log(NoahmpIO%zlvl-NoahmpIO%height_urban)/log(NoahmpIO%zlvl)
          NoahmpIO%height_urban = NoahmpIO%height_urban + NoahmpIO%urban_atmosphere_thickness
        END DO    
      ENDIF
@@ -1272,6 +1273,11 @@ contains
               call add_to_output(NoahmpIO%QLATXY     , "QLAT"     , "instantaneous lateral flow"                                   , "m"      )
             endif
            
+            ! Wetland model
+            if (NoahmpIO%IOPT_WETLAND > 0) then
+              call add_to_output(NoahmpIO%FSATXY      , "FSAT"    , "saturated fraction of the grid"                               , "-"      )
+              call add_to_output(NoahmpIO%WSURFXY     , "WSURF"   , "Wetland Water Storage"                                        , "mm"     )
+            endif
            ! For now, no urban output variables included
 
            enddo DEFINE_MODE_LOOP
@@ -1635,4 +1641,3 @@ SUBROUTINE CALC_DECLIN ( NOWDATE, LATITUDE, LONGITUDE, COSZ, JULIAN, &
 
 
 end module module_NoahMP_hrldas_driver
-

--- a/hrldas/IO_code/module_NoahMP_hrldas_driver.F
+++ b/hrldas/IO_code/module_NoahMP_hrldas_driver.F
@@ -59,7 +59,7 @@ contains
     implicit none
 
     integer      :: NTIME_out
-    real         :: max_utype_urb2d
+    real         :: max_landtype2d
     type(domain) :: grid
     ! initilization for stand alone parallel code.
     integer, optional, intent(in) :: wrfits,wrfite,wrfjts,wrfjte
@@ -180,9 +180,9 @@ contains
     NoahmpIO%kme = 2
   
     if ( (NoahmpIO%sf_urban_physics == 2) .or. (NoahmpIO%sf_urban_physics == 3) ) then
-       NoahmpIO%kde = NoahmpIO%num_urban_atmosphere
+       NoahmpIO%kde = NoahmpIO%num_urban_atmosphere + 1  ! to be consistent with kme
+       NoahmpIO%kme = NoahmpIO%num_urban_atmosphere + 1  ! bug fix for dimension of urban cell interfaces
        NoahmpIO%kte = NoahmpIO%num_urban_atmosphere
-       NoahmpIO%kme = NoahmpIO%num_urban_atmosphere
     endif
 
 !---------------------------------------------------------------------
@@ -565,12 +565,11 @@ contains
                               NoahmpIO%DL_U_BEP, NoahmpIO%SF_BEP, NoahmpIO%VL_BEP,                                          & !multi-layer urban
                               NoahmpIO%FRC_URB2D, NoahmpIO%UTYPE_URB2D, NoahmpIO%use_wudapt_lcz)                              !urban
 
-          max_utype_urb2d = maxval(NoahmpIO%UTYPE_URB2D)*1.0
-
-          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_utype_urb2d > 3.0) ) then  !new LCZ
+          max_landtype2d = maxval(NoahmpIO%IVGTYP)*1.0
+          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_landtype2d > 50.0) ) then   ! LCZ number: 51~61
              stop "USING 10 WUDAPT LCZ WITHOUT URBPARM_LCZ.TBL. SET USE_WUDAPT_LCZ=1"
           endif
-          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_utype_urb2d <= 3.0) ) then  ! new LCZ
+          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_landtype2d <= 50.0) ) then  ! LCZ number: 51~61
              stop "USING URBPARM_LCZ.TBL WITH OLD 3 URBAN CLASSES. SET USE_WUDAPT_LCZ=0"
           endif
 
@@ -704,14 +703,14 @@ contains
                               NoahmpIO%DL_U_BEP, NoahmpIO%SF_BEP, NoahmpIO%VL_BEP,                                         & !multi-layer urban
                               NoahmpIO%FRC_URB2D, NoahmpIO%UTYPE_URB2D, NoahmpIO%use_wudapt_lcz)                             !urban
 
-          max_utype_urb2d = maxval(NoahmpIO%UTYPE_URB2D)*1.0
-               
-          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_utype_urb2d > 3.0) ) then  !new LCZ
+          max_landtype2d = maxval(NoahmpIO%IVGTYP)*1.0
+          if ( (NoahmpIO%use_wudapt_lcz == 0) .and. (max_landtype2d > 50.0) ) then   ! LCZ number: 51~61
              stop "USING 10 WUDAPT LCZ WITHOUT URBPARM_LCZ.TBL. SET USE_WUDAPT_LCZ=1"
           endif
-          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_utype_urb2d <= 3.0) ) then  ! new LCZ
+          if ( (NoahmpIO%use_wudapt_lcz == 1) .and. (max_landtype2d <= 50.0) ) then  ! LCZ number: 51~61
              stop "USING URBPARM_LCZ.TBL WITH OLD 3 URBAN CLASSES. SET USE_WUDAPT_LCZ=0"
           endif
+
        endif !urban
 
        if ( NoahmpIO%SF_URBAN_PHYSICS > 1 ) then  !urban
@@ -884,27 +883,37 @@ contains
      NoahmpIO%SWDDIF = NoahmpIO%SWDOWN * 0.3                    ! following noahmplsm ATM 30% diffuse radiation
 
      IF(NoahmpIO%SF_URBAN_PHYSICS == 2 .or. NoahmpIO%SF_URBAN_PHYSICS == 3) THEN  ! BEP or BEM urban models
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban(:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:) /287.04/NoahmpIO%t_phy(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban    (:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban  (:,NoahmpIO%kde,:) = NoahmpIO%p8w(:,1,:) /287.04/NoahmpIO%t_phy(:,1,:)
        where(NoahmpIO%XLAND < 1.5) NoahmpIO%theta_urban(:,NoahmpIO%kde,:) = NoahmpIO%t_phy(:,1,:)*&
-                                                                   (100000.0/NoahmpIO%p8w(:,1,:))**(0.285714)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban(:,NoahmpIO%kde,:) = NoahmpIO%u_phy(:,1,:)
-       where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban(:,NoahmpIO%kde,:) = NoahmpIO%v_phy(:,1,:)
-       
-       NoahmpIO%height_urban = 0.5*(NoahmpIO%dz_urban(1,NoahmpIO%kde,1) + &
-                                 NoahmpIO%dz_urban(1,NoahmpIO%kde-1,1))
+                                                                            (100000.0/NoahmpIO%p8w(:,1,:))**(0.285714)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban    (:,NoahmpIO%kde,:) = NoahmpIO%u_phy(:,1,:)
+       where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban    (:,NoahmpIO%kde,:) = NoahmpIO%v_phy(:,1,:)
 
-       DO I = NoahmpIO%KDE-1, NoahmpIO%KDS, -1
+       ! allow one more dummy layer at the top to be consistent with cell interface array dimension
+       NoahmpIO%p_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%p_urban(:,NoahmpIO%kde,:)
+       NoahmpIO%rho_urban  (:,NoahmpIO%kde-1,:) = NoahmpIO%rho_urban(:,NoahmpIO%kde,:)
+       NoahmpIO%theta_urban(:,NoahmpIO%kde-1,:) = NoahmpIO%theta_urban(:,NoahmpIO%kde,:)
+       NoahmpIO%u_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%u_urban(:,NoahmpIO%kde,:)
+       NoahmpIO%v_urban    (:,NoahmpIO%kde-1,:) = NoahmpIO%v_urban(:,NoahmpIO%kde,:)
+
+       NoahmpIO%height_urban = 0.5*(NoahmpIO%dz_urban(1,NoahmpIO%kde-1,1) + &
+                               NoahmpIO%dz_urban(1,NoahmpIO%kde-2,1))
+       
+       do i = 3, NoahmpIO%kde
+           where(NoahmpIO%XLAND < 1.5) NoahmpIO%QV_CURR(:,i,:) = NoahmpIO%QV_CURR(:,1,:)
+       enddo
+
+       DO I = NoahmpIO%kde-2, NoahmpIO%kds, -1
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%p_urban(:,i,:) = NoahmpIO%p8w(:,1,:)* &
-                                                             exp(9.8*NoahmpIO%height_urban/287.04/NoahmpIO%t_phy(:,1,:))
-         where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,i,:) = NoahmpIO%p_urban(:,i,:)/287.04/ &
-                                                             NoahmpIO%t_phy(:,1,:)
+                                                               exp(9.8*NoahmpIO%height_urban/287.04/NoahmpIO%t_phy(:,1,:))
+         where(NoahmpIO%XLAND < 1.5) NoahmpIO%rho_urban(:,i,:) = NoahmpIO%p_urban(:,i,:)/287.04/NoahmpIO%t_phy(:,1,:)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%theta_urban(:,i,:) = NoahmpIO%t_phy(:,1,:)* &
-                                                             (100000.0/NoahmpIO%p_urban(:,i,:))**(0.285714)
+                                                                   (100000.0/NoahmpIO%p_urban(:,i,:))**(0.285714)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%u_urban(:,i,:) = NoahmpIO%u_urban(:,NoahmpIO%kde,:)* &
-                                                             log(NoahmpIO%zlvl-NoahmpIO%height_urban)/log(NoahmpIO%zlvl)
+                                                               log(max(NoahmpIO%zlvl-NoahmpIO%height_urban,1.001))/log(NoahmpIO%zlvl)
          where(NoahmpIO%XLAND < 1.5) NoahmpIO%v_urban(:,i,:) = NoahmpIO%v_urban(:,NoahmpIO%kde,:)* &
-                                                             log(NoahmpIO%zlvl-NoahmpIO%height_urban)/log(NoahmpIO%zlvl)
+                                                               log(max(NoahmpIO%zlvl-NoahmpIO%height_urban,1.001))/log(NoahmpIO%zlvl)
          NoahmpIO%height_urban = NoahmpIO%height_urban + NoahmpIO%urban_atmosphere_thickness
        END DO    
      ENDIF
@@ -1272,12 +1281,13 @@ contains
               call add_to_output(NoahmpIO%QSLATXY    , "QSLAT"    , "accumulated lateral flow"                                     , "mm"     )
               call add_to_output(NoahmpIO%QLATXY     , "QLAT"     , "instantaneous lateral flow"                                   , "m"      )
             endif
-           
+
             ! Wetland model
             if (NoahmpIO%IOPT_WETLAND > 0) then
               call add_to_output(NoahmpIO%FSATXY      , "FSAT"    , "saturated fraction of the grid"                               , "-"      )
               call add_to_output(NoahmpIO%WSURFXY     , "WSURF"   , "Wetland Water Storage"                                        , "mm"     )
             endif
+           
            ! For now, no urban output variables included
 
            enddo DEFINE_MODE_LOOP

--- a/hrldas/IO_code/module_hrldas_netcdf_io.F
+++ b/hrldas/IO_code/module_hrldas_netcdf_io.F
@@ -752,6 +752,72 @@ contains
   end subroutine read_crop_input
 
 !---------------------------------------------------------------------------------------------------------
+  subroutine read_wetland_input(wrfinput_flnm,                            &
+       xstart, xend,                                                   &
+       ystart, yend,                                                   &
+       fsatmx, wcap)
+    implicit none
+    character(len=*),          intent(in)  :: wrfinput_flnm
+    integer,                   intent(in)  :: xstart, xend, ystart, yend
+    real,    dimension(xstart:xend,  ystart:yend), intent(out) :: fsatmx
+    real,    dimension(xstart:xend,  ystart:yend), intent(out) :: wcap
+
+    character(len=256) :: units
+    character(len=24)  :: name
+    integer :: ierr,iret
+    integer :: ncid, varid
+    integer :: rank
+
+#ifdef _PARALLEL_  
+    call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
+    if (ierr /= MPI_SUCCESS) stop "MPI_COMM_RANK"
+#else
+    rank = 0
+#endif
+
+
+    ! Open the NetCDF file.
+    if (rank == 0) write(*,'("wrfinput_flnm: ''", A, "''")') trim(wrfinput_flnm)
+#ifdef _PARALLEL_
+    ierr = nf90_open_par(wrfinput_flnm, NF90_NOWRITE, MPI_COMM_WORLD, MPI_INFO_NULL, ncid)
+#else
+    ierr = nf90_open(wrfinput_flnm, NF90_NOWRITE, ncid)
+#endif
+    if (ierr /= 0) then
+       write(*,'("read_wetland_input:  Problem opening wrfinput file: ''", A, "''")') trim(wrfinput_flnm)
+#ifdef _PARALLEL_
+       call mpi_finalize(ierr)
+       if (ierr /= 0) write(*, '("Problem with MPI_finalize.")')
+#endif
+       stop
+    endif
+
+! Get maximum saturated fraction (FSATMX)
+    name = "FSATMX"
+    iret = nf90_inq_varid(ncid,  name,  varid)
+    if (iret == 0) then
+      ierr = nf90_get_var(ncid, varid, fsatmx, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+    else
+      write(*,*) "MODULE_HRLDAS_NETCDF_IO:  Problem finding variable '"//trim(name)//"' in NetCDF file. Using default values."
+    endif
+
+! Get maximum water storeage (WSTORE)
+    name = "WCAP"
+    iret = nf90_inq_varid(ncid,  name,  varid)
+    if (iret == 0) then
+      ierr = nf90_get_var(ncid, varid, wcap, start=(/xstart,ystart/), count=(/xend-xstart+1,yend-ystart+1/))
+    else
+      write(*,*) "MODULE_HRLDAS_NETCDF_IO:  Problem finding variable '"//trim(name)//"' in NetCDF file. Using default values."
+    endif
+
+
+! Close the NetCDF file
+    ierr = nf90_close(ncid)
+    if (ierr /= 0) stop "MODULE_NOAHLSM_HRLDAS_INPUT:  read_wetland_input:  NF90_CLOSE"
+
+  end subroutine read_wetland_input
+
+!---------------------------------------------------------------------------------------------------------
 
   subroutine read_tile_drain_map(tdinput_flnm,                            &
        xstart, xend,                                                      &

--- a/hrldas/run/Makefile
+++ b/hrldas/run/Makefile
@@ -181,6 +181,8 @@ OBJS = \
         ../../noahmp/src/SurfaceEmissivityGlacierMod.o \
         ../../noahmp/src/SurfaceEnergyFluxGlacierMod.o \
         ../../noahmp/src/SurfaceRadiationGlacierMod.o \
+        ../../noahmp/src/RunoffSurfaceWetlandMod.o \
+        ../../noahmp/src/WaterWetlandMod.o \
         ../../noahmp/src/WaterMainGlacierMod.o
 
 CMD = hrldas.exe

--- a/hrldas/run/README.namelist
+++ b/hrldas/run/README.namelist
@@ -162,6 +162,11 @@
                                                              !   7 -> Xinanjiang Infiltration and surface runoff scheme ((Jayawardena and Zhou, 2000)
                                                              !   8 -> Dynamic VIC surface runoff scheme (Liang and Xie, 2001)
 
+ WETLAND_OPTION                    = 0                       ! options for wetland model [default = 0]
+                                                             ! wetland water budget model in (Zhang et al. 2022 WRR)
+                                                             !   1 -> Single point, read parameters from table 
+                                                             !   2 -> 2-D, read parameters from the input file
+
  DVIC_INFILTRATION_OPTION          = 1                       ! options for infiltration in dynamic VIC runoff scheme (only works when RUNOFF_OPTION=8, default=1)
                                                              ! **1 -> Philip scheme
                       					     !   2 -> Green-Ampt scheme

--- a/hrldas/run/namelist.hrldas_example
+++ b/hrldas/run/namelist.hrldas_example
@@ -29,6 +29,7 @@
  BTR_OPTION                        = 1
  SURFACE_RUNOFF_OPTION             = 3
  SUBSURFACE_RUNOFF_OPTION          = 3
+ WETLAND_OPTION                    = 0
  DVIC_INFILTRATION_OPTION          = 1
  SURFACE_DRAG_OPTION               = 1
  FROZEN_SOIL_OPTION                = 1


### PR DESCRIPTION
This PR is associated with the PR#97 in noahmp repo:
https://github.com/NCAR/noahmp/pull/97

Implementing a wetland water storage model from Zhang et al. 2022 WRR (https://doi.org/10.1029/2021WR030573)
The wetland code has been refactored to the newest version of Noah-MP LSM.
To activate the wetland, a new namelist entry has been added:
wetland_option = 1 : for single point
wetland_option = 2 : for 2D regional

Initial test with the refactor wetland code at single point is conducted with the Fen site data from SK, Canada, for three years (see attached pdf). 

[Test_Wetland_Code_Output.pdf](https://github.com/NCAR/hrldas/files/12434888/Test_Wetland_Code_Output.pdf)
