### PR TITLE
correct specific humidity magnitude for ERA5-Land forcing

### DIFF
--- a/hrldas/HRLDAS_forcing/run/examples/ERA5/Prepare_ERA5-Land_Forcing.sh
+++ b/hrldas/HRLDAS_forcing/run/examples/ERA5/Prepare_ERA5-Land_Forcing.sh
@@ -162,7 +162,8 @@ for f in $FILES; do
    cdo -s merge $outfile1 $SP_file $outfile2
 
    outfile3=$(sed 's/'2D'/'Q'/g' <<< $f)
-   cdo -s -setparam,133.128 -expr,"var133=(0.622*var1)/(var134/100.-(0.378*var1))/1000." $outfile2 $outfile3
+   cdo -s -setparam,133.128 -expr,"var133=(0.622*var1)/(var134/100.-(0.378*var1))" $outfile2 $outfile3
+   # the output specific humidity in unit [kg/kg]
 done
 echo ""
 


### PR DESCRIPTION
This bug was reported in this issue: https://github.com/NCAR/hrldas/issues/203

This pull request is to correct the specific humidity magnitude in preprocessing ERA5-Land data in bash code
https://github.com/NCAR/hrldas/blob/master/hrldas/HRLDAS_forcing/run/examples/ERA5/Prepare_ERA5-Land_Forcing.sh
https://github.com/NCAR/hrldas/blob/087f1fd78601b37eaeead93da9f30253441f7cc2/hrldas/HRLDAS_forcing/run/examples/ERA5/Prepare_ERA5-Land_Forcing.sh#L165

According to Bolton 1980: https://archive.eol.ucar.edu/projects/ceop/dm/documents/refdata_report/eqns.html
The output specific humidity unit is already in [kg/kg], thus no need to divide it again by 1000. 