### PR TITLE
Bug fix for writing DY global attribute to hrldas_setup file

### DIFF
--- a/hrldas/HRLDAS_forcing/create_forcing.F
+++ b/hrldas/HRLDAS_forcing/create_forcing.F
@@ -2380,7 +2380,7 @@ subroutine open_netcdf_for_output(output_flnm, ncid, version, ix, jx, geo_em, in
   ierr = nf90_put_att(ncid, NF90_GLOBAL, "DX", geo_em%proj%dx)
   call error_handler(ierr, "Problem nf90_put_att DX")
 
-  ierr = nf90_put_att(ncid, NF90_GLOBAL, "DY", geo_em%proj%dx)
+  ierr = nf90_put_att(ncid, NF90_GLOBAL, "DY", geo_em%proj%dy)
   call error_handler(ierr, "Problem nf90_put_att DY")
 
   ierr = nf90_put_att(ncid, NF90_GLOBAL, "TRUELAT1", geo_em%proj%truelat1)

--- a/hrldas/HRLDAS_forcing/lib/module_geo_em.F
+++ b/hrldas/HRLDAS_forcing/lib/module_geo_em.F
@@ -279,7 +279,7 @@ contains
 
        ! For Cassini projection, module_llxy assumes a spherical earth
        ! with circumference EARTH_CIRC_M
-       latinc = 360.0*dx/EARTH_CIRC_M
+       latinc = 360.0*dy/EARTH_CIRC_M
        loninc = 360.0*dx/EARTH_CIRC_M
 
        call map_set(PROJ_CASSINI, geo_em%proj, lat1=la1, lon1=lo1, latinc=latinc, loninc=loninc, &

--- a/hrldas/HRLDAS_forcing/lib/module_geo_em.F
+++ b/hrldas/HRLDAS_forcing/lib/module_geo_em.F
@@ -68,6 +68,7 @@ contains
     real                              :: truelat2
     real                              :: stdlon
     real                              :: dx
+    real                              :: dy
     real                              :: latinc
     real                              :: loninc
     real                              :: la1
@@ -222,8 +223,11 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_LC, geo_em%proj, lat1=la1, lon1=lo1, knowni=1.0, knownj=1.0, &
-            truelat1=truelat1, truelat2=truelat2, stdlon=stdlon, dx=dx)
+            truelat1=truelat1, truelat2=truelat2, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_PS) then
 
@@ -236,8 +240,11 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_PS, geo_em%proj, lat1=la1, lon1=lo1, truelat1=truelat1, &
-            knowni=1.0, knownj=1.0, stdlon=stdlon, dx=dx)
+            knowni=1.0, knownj=1.0, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_MERC) then
 
@@ -247,8 +254,11 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_MERC, geo_em%proj, lat1=la1, lon1=lo1, knowni=1.0, knownj=1.0, &
-            truelat1=truelat1, dx=dx)
+            truelat1=truelat1, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_CASSINI) then
 
@@ -264,13 +274,16 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "STAND_LON", stdlon)
        call error_handler(iret, "STOP:  nf90_get_att:  STAND_LON")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        ! For Cassini projection, module_llxy assumes a spherical earth
        ! with circumference EARTH_CIRC_M
        latinc = 360.0*dx/EARTH_CIRC_M
        loninc = 360.0*dx/EARTH_CIRC_M
 
        call map_set(PROJ_CASSINI, geo_em%proj, lat1=la1, lon1=lo1, latinc=latinc, loninc=loninc, &
-            knowni=1.0, knownj=1.0, lat0=pole_lat, lon0=pole_lon, stdlon=stdlon)
+            knowni=1.0, knownj=1.0, lat0=pole_lat, lon0=pole_lon, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_LATLON) then
        stop "PROJ_LATLON is not a valid map projection for WRF."

--- a/hrldas/HRLDAS_forcing/lib/module_llxy.F
+++ b/hrldas/HRLDAS_forcing/lib/module_llxy.F
@@ -261,7 +261,7 @@ MODULE module_llxy
    END SUBROUTINE map_init
 
 
-   SUBROUTINE map_set(proj_code, proj, lat1, lon1, lat0, lon0, knowni, knownj, dx, latinc, &
+   SUBROUTINE map_set(proj_code, proj, lat1, lon1, lat0, lon0, knowni, knownj, dx, dy, latinc, &
                       loninc, stdlon, truelat1, truelat2, nlat, nlon, ixdim, jydim, &
                       stagger, phi, lambda, r_earth)
       ! Given a partially filled proj_info structure, this routine computes
@@ -290,6 +290,7 @@ MODULE module_llxy
       REAL, INTENT(IN), OPTIONAL        :: lat0
       REAL, INTENT(IN), OPTIONAL        :: lon0
       REAL, INTENT(IN), OPTIONAL        :: dx
+      REAL, INTENT(IN), OPTIONAL        :: dy
       REAL, INTENT(IN), OPTIONAL        :: stdlon
       REAL, INTENT(IN), OPTIONAL        :: truelat1
       REAL, INTENT(IN), OPTIONAL        :: truelat2
@@ -314,9 +315,10 @@ MODULE module_llxy
               .NOT.PRESENT(knowni) .OR. &
               .NOT.PRESENT(knownj) .OR. &
               .NOT.PRESENT(stdlon) .OR. &
-              .NOT.PRESENT(dx) ) THEN
+              .NOT.PRESENT(dx) .OR. &
+              .NOT.PRESENT(dy) ) THEN
             PRINT '(A,I2)', 'The following are mandatory parameters for projection code : ', proj_code
-            PRINT '(A)', ' truelat1, truelat2, lat1, lon1, knowni, knownj, stdlon, dx'
+            PRINT '(A)', ' truelat1, truelat2, lat1, lon1, knowni, knownj, stdlon, dx, dy'
             STOP 'MAP_INIT'
          END IF
       ELSE IF ( proj_code == PROJ_PS ) THEN
@@ -326,9 +328,10 @@ MODULE module_llxy
               .NOT.PRESENT(knowni) .OR. &
               .NOT.PRESENT(knownj) .OR. &
               .NOT.PRESENT(stdlon) .OR. &
-              .NOT.PRESENT(dx) ) THEN
+              .NOT.PRESENT(dx) .OR. &
+              .NOT.PRESENT(dy) ) THEN
             PRINT '(A,I2)', 'The following are mandatory parameters for projection code : ', proj_code
-            PRINT '(A)', ' truelat1, lat1, lon1, knonwi, knownj, stdlon, dx'
+            PRINT '(A)', ' truelat1, lat1, lon1, knonwi, knownj, stdlon, dx, dy'
             STOP 'MAP_INIT'
          END IF
       ELSE IF ( proj_code == PROJ_PS_WGS84 ) THEN
@@ -362,9 +365,10 @@ MODULE module_llxy
               .NOT.PRESENT(lon1) .OR. &
               .NOT.PRESENT(knowni) .OR. &
               .NOT.PRESENT(knownj) .OR. &
-              .NOT.PRESENT(dx) ) THEN
+              .NOT.PRESENT(dx) .OR. &
+              .NOT.PRESENT(dy) ) THEN
             PRINT '(A,I2)', 'The following are mandatory parameters for projection code : ', proj_code
-            PRINT '(A)', ' truelat1, lat1, lon1, knowni, knownj, dx'
+            PRINT '(A)', ' truelat1, lat1, lon1, knowni, knownj, dx, dy'
             STOP 'MAP_INIT'
          END IF
       ELSE IF ( proj_code == PROJ_LATLON ) THEN
@@ -395,9 +399,11 @@ MODULE module_llxy
               .NOT.PRESENT(lon0) .OR. &
               .NOT.PRESENT(knowni) .OR. &
               .NOT.PRESENT(knownj) .OR. &
-              .NOT.PRESENT(stdlon) ) THEN
+              .NOT.PRESENT(stdlon)  .OR. &
+              .NOT.PRESENT(dx) .OR. &
+              .NOT.PRESENT(dy) ) THEN
             PRINT '(A,I2)', 'The following are mandatory parameters for projection code : ', proj_code
-            PRINT '(A)', ' latinc, loninc, lat1, lon1, knowni, knownj, lat0, lon0, stdlon'
+            PRINT '(A)', ' latinc, loninc, lat1, lon1, knowni, knownj, lat0, lon0, stdlon, dx, dy'
             STOP 'MAP_INIT'
          END IF
       ELSE IF ( proj_code == PROJ_GAUSS ) THEN
@@ -476,7 +482,14 @@ MODULE module_llxy
             STOP 'MAP_INIT'
          ENDIF
       ENDIF
-  
+
+      IF ( PRESENT(dy) ) THEN
+         IF ((dy .LE. 0.).AND.(proj_code .NE. PROJ_LATLON)) THEN
+            PRINT '(A)', 'Require grid spacing (dy) in meters be positive'
+            STOP 'MAP_INIT'
+         ENDIF
+      ENDIF
+ 
       IF ( PRESENT(stdlon) ) THEN
          dummy_stdlon = stdlon
          IF ((ABS(dummy_stdlon) > 180.).AND.(proj_code /= PROJ_MERC)) THEN
@@ -512,6 +525,7 @@ MODULE module_llxy
       IF ( PRESENT(knowni) )   proj%knowni   = knowni
       IF ( PRESENT(knownj) )   proj%knownj   = knownj
       IF ( PRESENT(dx) )       proj%dx       = dx
+      IF ( PRESENT(dy) )       proj%dy       = dy
       IF ( PRESENT(stdlon) )   proj%stdlon   = dummy_stdlon
       IF ( PRESENT(truelat1) ) proj%truelat1 = truelat1
       IF ( PRESENT(truelat2) ) proj%truelat2 = truelat2

--- a/hrldas/HRLDAS_forcing/lib/module_wrfinputfile.F
+++ b/hrldas/HRLDAS_forcing/lib/module_wrfinputfile.F
@@ -174,7 +174,7 @@ contains
 
        ! For Cassini projection, module_llxy assumes a spherical earth
        ! with circumference EARTH_CIRC_M
-       latinc = 360.0*dx/EARTH_CIRC_M
+       latinc = 360.0*dy/EARTH_CIRC_M
        loninc = 360.0*dx/EARTH_CIRC_M
 
        call map_set(PROJ_CASSINI, wrfinput%proj, lat1=la1, lon1=lo1, latinc=latinc, loninc=loninc, &

--- a/hrldas/HRLDAS_forcing/lib/module_wrfinputfile.F
+++ b/hrldas/HRLDAS_forcing/lib/module_wrfinputfile.F
@@ -44,6 +44,7 @@ contains
     real                              :: truelat2
     real                              :: stdlon
     real                              :: dx
+    real                              :: dy
     real                              :: latinc
     real                              :: loninc
     real                              :: la1
@@ -117,8 +118,11 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_LC, wrfinput%proj, lat1=la1, lon1=lo1, knowni=1.0, knownj=1.0, &
-            truelat1=truelat1, truelat2=truelat2, stdlon=stdlon, dx=dx)
+            truelat1=truelat1, truelat2=truelat2, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_PS) then
 
@@ -131,8 +135,11 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_PS, wrfinput%proj, lat1=la1, lon1=lo1, truelat1=truelat1, &
-            knowni=1.0, knownj=1.0, stdlon=stdlon, dx=dx)
+            knowni=1.0, knownj=1.0, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_MERC) then
 
@@ -142,13 +149,19 @@ contains
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
 
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
+
        call map_set(PROJ_MERC, wrfinput%proj, lat1=la1, lon1=lo1, knowni=1.0, knownj=1.0, &
-            truelat1=truelat1, dx=dx)
+            truelat1=truelat1, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_CASSINI) then
 
        iret = nf90_get_att(ncid, NF90_GLOBAL, "DX" , dx)
        call error_handler(iret, "STOP:  nf90_get_att:  DX")
+
+       iret = nf90_get_att(ncid, NF90_GLOBAL, "DY" , dy)
+       call error_handler(iret, "STOP:  nf90_get_att:  DY")
 
        iret = nf90_get_att(ncid, NF90_GLOBAL, "POLE_LAT" , pole_lat)
        call error_handler(iret, "STOP:  nf90_get_att:  POLE_LAT")
@@ -165,7 +178,7 @@ contains
        loninc = 360.0*dx/EARTH_CIRC_M
 
        call map_set(PROJ_CASSINI, wrfinput%proj, lat1=la1, lon1=lo1, latinc=latinc, loninc=loninc, &
-            knowni=1.0, knownj=1.0, lat0=pole_lat, lon0=pole_lon, stdlon=stdlon)
+            knowni=1.0, knownj=1.0, lat0=pole_lat, lon0=pole_lon, stdlon=stdlon, dx=dx, dy=dy)
 
     else if (map_proj == PROJ_LATLON) then
        stop "PROJ_LATLON is not a valid map projection for WRF."

--- a/hrldas/HRLDAS_forcing/run/examples/vector/create_setup.ncl
+++ b/hrldas/HRLDAS_forcing/run/examples/vector/create_setup.ncl
@@ -178,8 +178,8 @@ outfile = addfile(setup_filename+".nc","c")
 
 
 outfile@TITLE = "OUTPUT FROM VECTOR CREATION SCRIPTS: m.barlage v20150608" ;
-outfile@DX        = 1000.0  ; not used
-outfile@DY        = 1000.0  ; not used
+outfile@DX        = 1000.0  ; 
+outfile@DY        = 1000.0  ; 
 outfile@TRUELAT1  = 45.0    ; not used
 outfile@TRUELAT2  = 45.0    ; not used
 outfile@STAND_LON = 45.0    ; not used


### PR DESCRIPTION
This PR is to fix the bug for writing the global attribute "DY" from geo_em file to hrldas_setup file.

Test on Derecho has been successful.