### PR TITLE
fix urban restart, allocation variables issue and units of evaporation for imp_scheme==2 in slucm

### DIFF
--- a/hrldas/IO_code/module_NoahMP_hrldas_driver.F
+++ b/hrldas/IO_code/module_NoahMP_hrldas_driver.F
@@ -1441,7 +1441,7 @@ subroutine lsm_restart()
   call prepare_restart_file (trim(NoahmpIO%outdir), version, NoahmpIO%igrid, NoahmpIO%llanduse, &
               NoahmpIO%olddate, NoahmpIO%startdate, NoahmpIO%ixfull, NoahmpIO%jxfull,  &
               NoahmpIO%ixpar, NoahmpIO%jxpar, NoahmpIO%xstartpar, NoahmpIO%ystartpar,  &
-              NoahmpIO%NSOIL, NoahmpIO%nsnow, NoahmpIO%NUMRAD, NoahmpIO%max_urban_dim, &
+              NoahmpIO%NSOIL, NoahmpIO%nsnow, NoahmpIO%NUMRAD,                         &
               NoahmpIO%dx, NoahmpIO%dy, NoahmpIO%truelat1, NoahmpIO%truelat2,          &
               NoahmpIO%mapproj, NoahmpIO%lat1, NoahmpIO%lon1, NoahmpIO%cen_lon,        &
               NoahmpIO%iswater, NoahmpIO%ivgtyp,               &
@@ -1450,7 +1450,8 @@ subroutine lsm_restart()
               NoahmpIO%urban_map_zd,  NoahmpIO%urban_map_zdf,  &
               NoahmpIO%urban_map_bd,  NoahmpIO%urban_map_wd,   &
               NoahmpIO%urban_map_gbd, NoahmpIO%urban_map_fbd,  &
-              NoahmpIO%urban_map_zgrd, NoahmpIO%num_urban_ndm)
+              NoahmpIO%urban_map_zgrd,NoahmpIO%num_urban_ndm,  &
+              NoahmpIO%SF_URBAN_PHYSICS)
   
   call add_to_restart(NoahmpIO%TSLB      , "SOIL_T", layers="SOIL")
   call add_to_restart(NoahmpIO%TSNOXY    , "SNOW_T", layers="SNOW")

--- a/hrldas/IO_code/module_NoahMP_hrldas_driver.F
+++ b/hrldas/IO_code/module_NoahMP_hrldas_driver.F
@@ -1450,7 +1450,7 @@ subroutine lsm_restart()
               NoahmpIO%urban_map_zd,  NoahmpIO%urban_map_zdf,  &
               NoahmpIO%urban_map_bd,  NoahmpIO%urban_map_wd,   &
               NoahmpIO%urban_map_gbd, NoahmpIO%urban_map_fbd,  &
-              NoahmpIO%urban_map_zgrd)
+              NoahmpIO%urban_map_zgrd, NoahmpIO%num_urban_ndm)
   
   call add_to_restart(NoahmpIO%TSLB      , "SOIL_T", layers="SOIL")
   call add_to_restart(NoahmpIO%TSNOXY    , "SNOW_T", layers="SNOW")

--- a/hrldas/IO_code/module_NoahMP_hrldas_driver.F
+++ b/hrldas/IO_code/module_NoahMP_hrldas_driver.F
@@ -614,6 +614,15 @@ contains
 
        endif ! NoahmpIO%SF_URBAN_PHYSICS
 
+       if ( NoahmpIO%SF_URBAN_PHYSICS > 1 ) then  !urban
+          do i = 1, NoahmpIO%num_urban_atmosphere-1
+             NoahmpIO%dz_urban(:,i,:) = NoahmpIO%urban_atmosphere_thickness  ! thickness of full levels
+          enddo
+          NoahmpIO%dz_urban(:,NoahmpIO%num_urban_atmosphere,:) =                                   &
+                       2*(NoahmpIO%zlvl - NoahmpIO%urban_atmosphere_thickness*(NoahmpIO%num_urban_atmosphere-1))
+          print*, NoahmpIO%dz_urban(1,:,1)
+       endif
+
     else
 
        NoahmpIO%restart_flag = .false.
@@ -959,7 +968,7 @@ contains
          NoahmpIO%height_urban = NoahmpIO%height_urban + NoahmpIO%urban_atmosphere_thickness
        END DO    
      ENDIF
-  
+
 !------------------------------------------------------------------------
 ! Noah-MP updates we can do before spatial loop.
 !------------------------------------------------------------------------

--- a/hrldas/IO_code/module_hrldas_netcdf_io.F
+++ b/hrldas/IO_code/module_hrldas_netcdf_io.F
@@ -3756,7 +3756,6 @@ contains
         ierr = nf90_def_dim(ncid, "ugbd_layers", urban_map_gbd, dimid_ugbd)
         ierr = nf90_def_dim(ncid, "ufbd_layers", urban_map_fbd, dimid_ufbd)
         ierr = nf90_def_dim(ncid, "zgrd_layers", urban_map_zgrd, dimid_zgrd)
-        ierr = nf90_def_dim(ncid, "undm_layers", urban_map_ndm, dimid_undm)
     endif
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "TITLE", "RESTART FILE FROM HRLDAS "//version)

--- a/hrldas/IO_code/module_hrldas_netcdf_io.F
+++ b/hrldas/IO_code/module_hrldas_netcdf_io.F
@@ -3579,7 +3579,7 @@ contains
        nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,&
        iswater, vegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd)
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm)
 
     implicit none
 
@@ -3610,6 +3610,7 @@ contains
     integer,                               intent(in) :: urban_map_gbd
     integer,                               intent(in) :: urban_map_fbd
     integer,                               intent(in) :: urban_map_zgrd
+    integer,                               intent(in) :: urban_map_ndm
     real(kind=kind_noahmp),                intent(in) :: dx, dy
     real(kind=kind_noahmp),                intent(in) :: truelat1, truelat2
     integer,                               intent(in) :: mapproj
@@ -3625,7 +3626,7 @@ contains
        nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon, &
        iswater, gvegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd )
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm )
     endif 
 
     call mpp_land_sync()
@@ -3638,7 +3639,7 @@ contains
        nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,  &
        iswater, vegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd)
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm)
 
     implicit none
 #include <netcdf.inc>
@@ -3670,6 +3671,7 @@ contains
     integer,                               intent(in) :: urban_map_gbd
     integer,                               intent(in) :: urban_map_fbd
     integer,                               intent(in) :: urban_map_zgrd
+    integer,                               intent(in) :: urban_map_ndm
     real(kind=kind_noahmp),                intent(in) :: dx, dy
     real(kind=kind_noahmp),                intent(in) :: truelat1, truelat2
     integer,                               intent(in) :: mapproj
@@ -3686,7 +3688,7 @@ contains
                dimid_layers,dimid_snow_layers, dimid_sosn_layers,     &
                dimid_urban,dimid_numrad_layers,dimid_ubhi,dimid_uzrd, &
                dimid_uzwd,dimid_ubgd,dimid_ubzd,dimid_uzdf,dimid_ubbd,&
-               dimid_ubwd,dimid_ugbd,dimid_ufbd,dimid_zgrd
+               dimid_ubwd,dimid_ugbd,dimid_ufbd,dimid_zgrd,dimid_undm
     character(len=19) :: date19
     integer :: rank
 
@@ -3747,6 +3749,7 @@ contains
     ierr = nf90_def_dim(ncid, "ugbd_layers", urban_map_gbd, dimid_ugbd)
     ierr = nf90_def_dim(ncid, "ufbd_layers", urban_map_fbd, dimid_ufbd)
     ierr = nf90_def_dim(ncid, "zgrd_layers", urban_map_zgrd, dimid_zgrd)
+    ierr = nf90_def_dim(ncid, "undm_layers", urban_map_ndm, dimid_undm)
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "TITLE", "RESTART FILE FROM HRLDAS "//version)
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -1.E33)
@@ -4112,6 +4115,9 @@ contains
     else if (output_layers == "ZGRD") then
        ierr = nf90_inq_dimid(ncid, "zgrd_layers", dimid_kx)
        call error_handler(ierr, "ADD_TO_RESTART:  nf90_inq_dimid for 'zgrd_layers'")
+    else if (output_layers == "UNDM") then
+       ierr = nf90_inq_dimid(ncid, "undm_layers", dimid_kx)
+       call error_handler(ierr, "ADD_TO_RESTART:  nf90_inq_dimid for 'undm_layers'")       
     else
        stop "No vertical dimension found in restart save!"
     endif

--- a/hrldas/IO_code/module_hrldas_netcdf_io.F
+++ b/hrldas/IO_code/module_hrldas_netcdf_io.F
@@ -3576,10 +3576,11 @@ contains
 #ifdef MPP_LAND
       subroutine prepare_restart_file_mpp(outdir, version, igrid, llanduse, olddate, startdate,  &
        ixfull, jxfull, ixpar, jxpar, xstartpar, ystartpar,                                    &
-       nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,&
+       nsoil, nsnow, nrad, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,&
        iswater, vegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm)
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd,  &
+       urban_map_ndm,sf_urban_physics)
 
     implicit none
 
@@ -3598,7 +3599,6 @@ contains
     integer,                               intent(in) :: nsoil
     integer,                               intent(in) :: nsnow
     integer,                               intent(in) :: nrad
-    integer,                               intent(in) :: num_urban_layers
     integer,                               intent(in) :: num_urban_hi
     integer,                               intent(in) :: urban_map_zrd
     integer,                               intent(in) :: urban_map_zwd
@@ -3611,6 +3611,7 @@ contains
     integer,                               intent(in) :: urban_map_fbd
     integer,                               intent(in) :: urban_map_zgrd
     integer,                               intent(in) :: urban_map_ndm
+    integer,                               intent(in) :: sf_urban_physics
     real(kind=kind_noahmp),                intent(in) :: dx, dy
     real(kind=kind_noahmp),                intent(in) :: truelat1, truelat2
     integer,                               intent(in) :: mapproj
@@ -3623,10 +3624,11 @@ contains
     if(my_id .eq. io_id) then
       call prepare_restart_file_seq(outdir, version, igrid, llanduse, olddate, startdate,  &
        global_nx, global_ny, global_nx, global_ny, xstartpar, ystartpar,               &
-       nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon, &
+       nsoil, nsnow, nrad, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon, &
        iswater, gvegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm )
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, &
+       urban_map_ndm, sf_urban_physics )
     endif 
 
     call mpp_land_sync()
@@ -3636,10 +3638,11 @@ contains
 
   subroutine prepare_restart_file_seq(outdir, version, igrid, llanduse, olddate, startdate,  &
        ixfull, jxfull, ixpar, jxpar, xstartpar, ystartpar,                                    &
-       nsoil, nsnow, nrad, num_urban_layers, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,  &
+       nsoil, nsnow, nrad, dx, dy, truelat1, truelat2, mapproj, lat1, lon1, cen_lon,  &
        iswater, vegtyp, num_urban_hi, urban_map_zrd, urban_map_zwd, &
        urban_map_gd, urban_map_zd, urban_map_zdf,  urban_map_bd,    &
-       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd, urban_map_ndm)
+       urban_map_wd, urban_map_gbd, urban_map_fbd, urban_map_zgrd,  &
+       urban_map_ndm, sf_urban_physics)
 
     implicit none
 #include <netcdf.inc>
@@ -3659,7 +3662,6 @@ contains
     integer,                               intent(in) :: nsoil
     integer,                               intent(in) :: nsnow
     integer,                               intent(in) :: nrad
-    integer,                               intent(in) :: num_urban_layers
     integer,                               intent(in) :: num_urban_hi
     integer,                               intent(in) :: urban_map_zrd
     integer,                               intent(in) :: urban_map_zwd
@@ -3672,6 +3674,7 @@ contains
     integer,                               intent(in) :: urban_map_fbd
     integer,                               intent(in) :: urban_map_zgrd
     integer,                               intent(in) :: urban_map_ndm
+    integer,                               intent(in) :: sf_urban_physics
     real(kind=kind_noahmp),                intent(in) :: dx, dy
     real(kind=kind_noahmp),                intent(in) :: truelat1, truelat2
     integer,                               intent(in) :: mapproj
@@ -3686,7 +3689,7 @@ contains
     integer :: varid
     integer :: dimid_times,dimid_datelen,dimid_ix,dimid_jx,dimid_dum, &
                dimid_layers,dimid_snow_layers, dimid_sosn_layers,     &
-               dimid_urban,dimid_numrad_layers,dimid_ubhi,dimid_uzrd, &
+               dimid_numrad_layers,dimid_ubhi,dimid_uzrd,             &
                dimid_uzwd,dimid_ubgd,dimid_ubzd,dimid_uzdf,dimid_ubbd,&
                dimid_ubwd,dimid_ugbd,dimid_ufbd,dimid_zgrd,dimid_undm
     character(len=19) :: date19
@@ -3736,20 +3739,25 @@ contains
     ierr = nf90_def_dim(ncid, "soil_layers_stag", nsoil, dimid_layers)
     ierr = nf90_def_dim(ncid, "snow_layers", nsnow, dimid_snow_layers)
     ierr = nf90_def_dim(ncid, "sosn_layers", nsnow+nsoil, dimid_sosn_layers)
-    ierr = nf90_def_dim(ncid, "urban_layers", num_urban_layers, dimid_urban)
     ierr = nf90_def_dim(ncid, "rad_layers", nrad, dimid_numrad_layers)
-    ierr = nf90_def_dim(ncid, "ubhi_layers", num_urban_hi, dimid_ubhi)
-    ierr = nf90_def_dim(ncid, "uzrd_layers", urban_map_zrd, dimid_uzrd)
-    ierr = nf90_def_dim(ncid, "uzwd_layers", urban_map_zwd, dimid_uzwd)
-    ierr = nf90_def_dim(ncid, "ubgd_layers", urban_map_gd, dimid_ubgd)
-    ierr = nf90_def_dim(ncid, "ubzd_layers", urban_map_zd, dimid_ubzd)
-    ierr = nf90_def_dim(ncid, "uzdf_layers", urban_map_zdf, dimid_uzdf)
-    ierr = nf90_def_dim(ncid, "ubbd_layers", urban_map_bd, dimid_ubbd)
-    ierr = nf90_def_dim(ncid, "ubwd_layers", urban_map_wd, dimid_ubwd)
-    ierr = nf90_def_dim(ncid, "ugbd_layers", urban_map_gbd, dimid_ugbd)
-    ierr = nf90_def_dim(ncid, "ufbd_layers", urban_map_fbd, dimid_ufbd)
-    ierr = nf90_def_dim(ncid, "zgrd_layers", urban_map_zgrd, dimid_zgrd)
-    ierr = nf90_def_dim(ncid, "undm_layers", urban_map_ndm, dimid_undm)
+    
+    if ( (sf_urban_physics == 2) .or. (sf_urban_physics == 3) ) then
+        ierr = nf90_def_dim(ncid, "ubhi_layers", num_urban_hi, dimid_ubhi)
+        ierr = nf90_def_dim(ncid, "uzrd_layers", urban_map_zrd, dimid_uzrd)
+        ierr = nf90_def_dim(ncid, "uzwd_layers", urban_map_zwd, dimid_uzwd)
+        ierr = nf90_def_dim(ncid, "ubgd_layers", urban_map_gd, dimid_ubgd)
+        ierr = nf90_def_dim(ncid, "ubzd_layers", urban_map_zd, dimid_ubzd)
+        ierr = nf90_def_dim(ncid, "uzdf_layers", urban_map_zdf, dimid_uzdf)
+        ierr = nf90_def_dim(ncid, "undm_layers", urban_map_ndm, dimid_undm)
+    endif
+    if ( sf_urban_physics == 3 ) then
+        ierr = nf90_def_dim(ncid, "ubbd_layers", urban_map_bd, dimid_ubbd)
+        ierr = nf90_def_dim(ncid, "ubwd_layers", urban_map_wd, dimid_ubwd)
+        ierr = nf90_def_dim(ncid, "ugbd_layers", urban_map_gbd, dimid_ugbd)
+        ierr = nf90_def_dim(ncid, "ufbd_layers", urban_map_fbd, dimid_ufbd)
+        ierr = nf90_def_dim(ncid, "zgrd_layers", urban_map_zgrd, dimid_zgrd)
+        ierr = nf90_def_dim(ncid, "undm_layers", urban_map_ndm, dimid_undm)
+    endif
 
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "TITLE", "RESTART FILE FROM HRLDAS "//version)
     ierr = nf90_put_att(ncid, NF90_GLOBAL, "missing_value", -1.E33)
@@ -4076,9 +4084,6 @@ contains
     else if (output_layers == "SOSN") then
        ierr = nf90_inq_dimid(ncid, "sosn_layers", dimid_kx)
        call error_handler(ierr, "ADD_TO_RESTART:  nf90_inq_dimid for 'sosn_layers'")
-    else if (output_layers == "URBN") then
-       ierr = nf90_inq_dimid(ncid, "urban_layers", dimid_kx)
-       call error_handler(ierr, "ADD_TO_RESTART:  nf90_inq_dimid for 'urban_layers'")
     else if (output_layers == "RADN") then
        ierr = nf90_inq_dimid(ncid, "rad_layers", dimid_kx)
        call error_handler(ierr, "ADD_TO_RESTART:  nf90_inq_dimid for 'rad_layers'")

--- a/urban/wrf/module_sf_urban.F
+++ b/urban/wrf/module_sf_urban.F
@@ -984,8 +984,9 @@ use Machine, only : kind_noahmp
 
    IF (IMP_SCHEME==2) then
    IF (FLXHUMRP <= 0.) FLXHUMRP = 0. 
-!  Compute water retention depth from previous time step 
-   DrelR = DrelRP+(RAIN1-FLXHUMRP)*DELT/porimp(IMPR)
+!  Compute water retention depth from previous time step
+   ! Convert kinematic water flux to evaporation in m/s: multiply flux by rho_air/who_water in SI units
+   DrelR = DrelRP+(RAIN1-FLXHUMRP*RHOO/1000.)*DELT/porimp(IMPR)
    IF (RAIN > 0. .AND. DrelR < DrelRP) DrelR = DrelRP 
   
    IF (DrelR <= 0.) then
@@ -1233,9 +1234,10 @@ ENDIF
    IF (FLXHUMBP <= 0.) FLXHUMBP = 0. 
    IF (FLXHUMGP <= 0.) FLXHUMGP = 0. 
 ! Compute water retention from previous time step for wall and ground
-  DrelB = DrelBP+(RAIN1-FLXHUMBP)*DELT/porimp(IMPB) 
-    IF (RAIN > 0. .AND. DrelB < DrelBP) DrelB = DrelBP 
-  DrelG = DrelGP+(RAIN1-FLXHUMGP)*DELT/porimp(IMPG)  
+  ! Convert kinematic water flux to evaporation in m/s: multiply flux by rho_air/who_water in SI units
+  DrelB = DrelBP+(RAIN1-FLXHUMBP*RHOO/1000.)*DELT/porimp(IMPB)
+    IF (RAIN > 0. .AND. DrelB < DrelBP) DrelB = DrelBP
+  DrelG = DrelGP+(RAIN1-FLXHUMGP*RHOO/1000.)*DELT/porimp(IMPG)   
     IF (RAIN > 0. .AND. DrelG < DrelGP) DrelG = DrelGP 
   
   IF (DrelB <= 0.) then


### PR DESCRIPTION
Fix units of evaporation for imp_scheme==2 in slucm #308 
Fix Missing urban layer of "UNDM" in the restart file #319 

Link to NohaMP submodule https://github.com/NCAR/noahmp/pull/243

Tests perform, working fine for all SF_URBAN_PHYSICS option using HRLDAS for initial and restart runs